### PR TITLE
feat: align template with build standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Copier template for modern Python packages.
 
-**[→ Full documentation](https://YOUR_ORG.github.io/templatepy)**
+**[→ Full documentation](https://larsrollik.github.io/templatepy)**
 
 ## Stack
 
@@ -10,19 +10,20 @@ Copier template for modern Python packages.
 |---|---|
 | uv | dependency management, virtual environments |
 | hatchling + hatch-vcs | build backend; version from git tags |
-| commitizen | Conventional Commits enforcement; `cz bump` |
+| commitizen | Conventional Commits enforcement; auto bump on merge |
 | ruff | linting + formatting |
 | mypy | static type checking |
 | pytest + pytest-cov | testing with coverage |
+| gitleaks | secret scanning |
 
 ## Quickstart
 
 ```sh
 uv tool install copier
-copier copy gh:YOUR_ORG/templatepy my-new-project
+copier copy gh:larsrollik/templatepy my-new-project
 cd my-new-project
 git init && git add -A && git commit -m "chore: initial commit from templatepy"
-uv sync --group dev
+uv sync --extra dev
 uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
@@ -35,25 +36,41 @@ cd my-existing-project && copier update
 ## Release flow
 
 ```
-feature/bug branch  →  cz commit  →  cz bump  →  git push --follow-tags
-                                                         ↓
-                                       PR to main  →  lint + tests  →  merge
-                                                         ↓
-                                              tag triggers release.yml
-                                              → squash to prod
-                                              → GitHub release + changelog
-                                              → PyPI (if UV_PUBLISH_TOKEN set)
+feature branch  →  PR  →  CI gate (lint + test + secrets) must pass
+                           merge blocked until green
+                               ↓
+                           merge to main (rebase)
+                               ↓
+                           bump.yml fires: cz bump → tag vX.Y.Z
+                               ↓
+                           release.yml fires on tag:
+                           → GitHub release (wheel + sdist attached)
+                           → PyPI via OIDC trusted publishing (no stored token)
+                           → Zenodo webhook (if enabled)
 ```
 
-## Required secrets
+## PyPI setup (one-time per repo)
 
-| Secret | Purpose |
-|---|---|
-| `UV_PUBLISH_TOKEN` | PyPI publish — skipped gracefully if absent |
+Uses OIDC trusted publishing — no API token stored in GitHub secrets.
+
+1. pypi.org → project → Settings → Publishing → Add trusted publisher
+2. Owner: `<github-user>`, Repository: `<repo>`, Workflow: `release.yml`
+3. Done — the workflow handles authentication automatically.
+
+## Branch protection (required for CI gate)
+
+Repo settings → Branches → Add rule for `main`:
+- ✅ Require status checks: `CI` job
+- ✅ Require branches to be up to date
+- ✅ Require linear history
+
+For the auto-bump workflow to push the bump commit back to main:
+- ✅ Allow specified actors to bypass → add `github-actions[bot]`
 
 ## Docs
 
 ```sh
-uv tool install mkdocs-material
-mkdocs serve
+uv run mkdocs serve
 ```
+
+Deploy to GitHub Pages on push to main via `docs.yml` (automatic).

--- a/copier.yaml
+++ b/copier.yaml
@@ -1,5 +1,5 @@
 # templatepy — copier template configuration
-# Usage: copier copy gh:YOUR_ORG/templatepy my-new-project
+# Usage: copier copy gh:larsrollik/templatepy my-new-project
 # Update: copier update (inside an existing generated project)
 
 _subdirectory: template

--- a/template/.github/workflows/bump.yml
+++ b/template/.github/workflows/bump.yml
@@ -1,0 +1,47 @@
+name: Auto bump
+
+# Runs after every push to main. If there are bumpable conventional commits
+# since the last tag, creates a version bump commit + tag and pushes both.
+# The tag push then triggers release.yml.
+#
+# Loop prevention: skips if the triggering commit message starts with "bump:"
+# (i.e. the bump commit itself just pushed back to main).
+#
+# Branch protection: the github-actions bot must be allowed to push to main.
+# Repo settings → Branches → edit main rule →
+#   "Allow specified actors to bypass required pull requests" → add github-actions[bot]
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Version bump
+    runs-on: ubuntu-latest
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Bump version
+        run: |
+          uvx commitizen bump --yes || EXIT=$?
+          if [ "${EXIT:-0}" -eq 21 ]; then
+            echo "No bumpable commits since last tag — skipping release."
+            exit 0
+          fi
+          [ "${EXIT:-0}" -eq 0 ] || exit $EXIT
+          git push --follow-tags

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint
@@ -21,9 +24,9 @@ jobs:
           python-version: "[[ python_requires ]]"
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
-      - name: Run pre-commit (ruff + mypy + commitizen)
+      - name: Run pre-commit (ruff + mypy + commitizen + gitleaks)
         run: uv run pre-commit run --all-files --show-diff-on-failure
 
   test:
@@ -33,7 +36,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]   # extend as new stable releases land
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -44,7 +47,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
       - name: Run tests
         run: uv run pytest
@@ -54,19 +57,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: secret-scanner/action@0.2.1
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Aggregate gate — branch protection can require this job
   ci:
     name: CI
     runs-on: ubuntu-latest
-    needs: [lint, secrets-scan]
+    needs: [lint, test, secrets-scan]
     if: always()
     steps:
       - name: Check required jobs
         run: |
           if [[ "${{ needs.lint.result }}" != "success" ]]; then
             echo "lint failed" && exit 1
+          fi
+          if [[ "${{ needs.test.result }}" != "success" && "${{ needs.test.result }}" != "skipped" ]]; then
+            echo "test failed" && exit 1
           fi
           if [[ "${{ needs.secrets-scan.result }}" != "success" ]]; then
             echo "secrets-scan failed" && exit 1

--- a/template/.github/workflows/docs.yml
+++ b/template/.github/workflows/docs.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: "[[ python_requires ]]"
 
       - name: Install dependencies
-        run: uv sync --group dev
+        run: uv sync --extra dev
 
       - name: Deploy
         run: uv run mkdocs gh-deploy --force

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -7,90 +7,29 @@ on:
 
 permissions:
   contents: write
+  id-token: write  # required for PyPI OIDC trusted publishing
 
 jobs:
   release:
-    name: Squash → prod, release notes, GitHub release
+    name: Build, release, publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          fetch-depth: 0  # required for hatch-vcs to read tags
 
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      # ── Squash-merge main into prod ────────────────────────────────────
-      - name: Squash merge main → prod
-        run: |
-          git fetch origin
-
-          # Create prod branch if it doesn't exist yet
-          if git ls-remote --exit-code --heads origin prod > /dev/null 2>&1; then
-            git checkout prod
-            git pull origin prod
-          else
-            git checkout -b prod
-          fi
-
-          # Squash all changes from main
-          git merge --squash origin/main || true
-
-          # Resolve any conflicts by taking main's version wholesale
-          git checkout -f origin/main -- .
-          git add -A
-
-          if git diff --cached --quiet; then
-            echo "Nothing new to squash-merge."
-          else
-            git commit -m "release: ${{ github.ref_name }}"
-            git push origin prod
-          fi
-
-      # ── Generate changelog since previous tag ─────────────────────────
       - uses: astral-sh/setup-uv@v5
         with:
           python-version: "[[ python_requires ]]"
 
-      - name: Generate release notes
-        id: notes
-        run: |
-          CURRENT_TAG="${{ github.ref_name }}"
-          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${CURRENT_TAG}$" | head -1)
+      - name: Build
+        run: uv build
 
-          if [ -n "$PREV_TAG" ]; then
-            NOTES=$(uvx commitizen changelog --dry-run --start-rev "$PREV_TAG" 2>/dev/null \
-              || echo "Changes since ${PREV_TAG}")
-          else
-            NOTES=$(uvx commitizen changelog --dry-run 2>/dev/null \
-              || echo "Initial release")
-          fi
-
-          echo "content<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$NOTES"       >> "$GITHUB_OUTPUT"
-          echo "EOF"          >> "$GITHUB_OUTPUT"
-
-      # ── Create GitHub release ──────────────────────────────────────────
       - name: Create GitHub release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh release create "${{ github.ref_name }}" \
-            --title "Release ${{ github.ref_name }}" \
-            --notes "${{ steps.notes.outputs.content }}"
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: false
 
-      # ── Publish to PyPI ────────────────────────────────────────────────
-      # Add UV_PUBLISH_TOKEN to repository secrets to enable.
-      # Skips gracefully (green) if the secret is not configured.
-      - name: Build and publish to PyPI
-        env:
-          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: |
-          if [ -z "$UV_PUBLISH_TOKEN" ]; then
-            echo "UV_PUBLISH_TOKEN not configured — skipping PyPI publish."
-            exit 0
-          fi
-          uv build
-          uv publish
+      - name: Publish to PyPI
+        run: uv publish --trusted-publishing auto

--- a/template/CITATION.cff
+++ b/template/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "[[ project_name ]]"
+repository-code: https://github.com/[[ github_username ]]/[[ github_repo ]]
+url: https://github.com/[[ github_username ]]/[[ github_repo ]]
+license: GPL-3.0
+authors:
+  - family-names: [[ author_name.split()[-1] ]]
+    given-names: [[ author_name.split()[0] ]]
+    orcid: https://orcid.org/0000-0000-0000-0000  # replace with your ORCID
+
+# Zenodo integration (optional):
+# 1. Enable the Zenodo webhook at zenodo.org/account/settings/github
+# 2. After first tag release, copy the concept DOI from Zenodo and add:
+#
+# identifiers:
+#   - type: doi
+#     value: 10.5281/zenodo.XXXXXXX
+#     description: Zenodo concept DOI
+#
+# preferred-citation:
+#   type: software
+#   title: "[[ project_name ]]"
+#   authors:
+#     - family-names: ...
+#       given-names: ...
+#       orcid: https://orcid.org/...
+#   year: [[ year ]]
+#   publisher:
+#     name: Zenodo
+#   doi: 10.5281/zenodo.XXXXXXX
+#   url: https://doi.org/10.5281/zenodo.XXXXXXX

--- a/template/LICENSE
+++ b/template/LICENSE
@@ -2,6 +2,11 @@ Copyright (c) [[ year ]] [[ author_name ]]
 All rights reserved.
 
 No license is granted to use, copy, modify, merge, publish, distribute,
-sublicense, or sell copies of this software or its documentation.
+sublicense, or sell copies of this software or its documentation without
+explicit written permission from the copyright holder.
 
-Replace this file with your chosen license before publishing or sharing.
+Replace this file with your chosen open-source license before publishing.
+Preferred default for research code: GNU GPL v3.0 (retains authorship rights,
+requires attribution and source disclosure for derivatives).
+Permissive alternatives: MIT or BSD-3-Clause (allow commercial use without
+source disclosure — use only if explicitly intended).

--- a/template/README.md
+++ b/template/README.md
@@ -19,8 +19,8 @@ uv add [[ project_slug ]]
 ```sh
 git clone https://github.com/[[ github_username ]]/[[ github_repo ]].git
 cd [[ github_repo ]]
-uv sync --group dev
-uv run pre-commit install --hook-type commit-msg --hook-type pre-commit
+uv sync --extra dev
+uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
 ## Running tests
@@ -31,10 +31,10 @@ uv run pytest
 
 ## Release workflow
 
-1. Work on a `feature/` or `bug/` branch, committing with `cz commit`
-2. Before merging: `cz bump` → creates version tag on the branch
-3. `git push --follow-tags` → opens PR, CI runs lint + tests
-4. Merge PR → tag triggers automated release
+1. Work on a `feature/` or `fix/` branch, committing with `cz commit`
+2. Open a PR — CI (lint + tests + secrets scan) must pass before merge
+3. Merge to main → version bump and tag are created automatically
+4. Tag triggers release: GitHub release + PyPI publish
 
 ## License
 

--- a/template/pyproject.toml
+++ b/template/pyproject.toml
@@ -24,6 +24,7 @@ Repository = "https://github.com/[[ github_username ]]/[[ github_repo ]]"
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "1.0.0"
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/[[ project_slug ]]/_version.py"
@@ -38,7 +39,7 @@ include = ["/src", "/tests", "/README.md", "/LICENSE", "/pyproject.toml"]
 # Dependencies
 # ---------------------------------------------------------------------------
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "commitizen",
     "pytest>=8",


### PR DESCRIPTION
## Summary

- **CI**: replace `secret-scanner/action` with `gitleaks/gitleaks-action@v2` (no baseline file needed); add `permissions: contents: read`; include `test` in gate job (with `skipped` allowed for non-PR pushes)
- **Release**: drop `prod` branch squash step entirely; switch PyPI publish to `uv publish --trusted-publishing auto` (OIDC, no stored token); add `id-token: write` permission; use `softprops/action-gh-release@v2` (replaces deprecated `create-release@v1`)
- **bump.yml**: new workflow — auto `cz bump` on every push to main; skips if commit starts with `bump:` (loop prevention); exits cleanly (code 21) when no bumpable commits
- **pyproject.toml**: `[dependency-groups]` → `[project.optional-dependencies]` (pip-compatible); add `fallback-version = "1.0.0"`; start versions at 1.x
- **CITATION.cff**: added with Zenodo integration as commented optional block
- **LICENSE**: retain-rights placeholder with preference note (GPL-3.0 recommended for research, permissive only if explicitly intended)
- **README.md** (template + copier root): update quickstart, release flow, PyPI setup instructions, branch protection instructions; fix `YOUR_ORG` → `larsrollik`; fix `--group dev` → `--extra dev`

## Branch protection required in generated repos

For `bump.yml` to push the bump commit to protected main:
Repo settings → Branches → main rule → Allow specified actors to bypass → add `github-actions[bot]`

## PyPI trusted publishing — one-time per generated repo

pypi.org → project → Settings → Publishing → Add trusted publisher
Owner / Repository / Workflow: `release.yml` — no token stored in GitHub.