### PR TITLE
feat: choose GitHub App vs PAT auth for private-repo CI clones

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -82,8 +82,21 @@ license_type:
 
 private_repo_deps:
   type: bool
-  help: "Does this project depend on private GitHub repos (git+ deps)? Adds PRIVATE_REPO_ACCESS_TOKEN auth step to CI."
+  help: "Does this project depend on private GitHub repos (git+ deps)? Adds a git-auth step to CI so it can clone them."
   default: false
+
+private_repo_auth:
+  type: str
+  help: "How should CI authenticate to clone the private repos?"
+  when: "[[ private_repo_deps ]]"
+  default: app
+  choices:
+    # Org-owned GitHub App: per-run installation token, no user PAT. CI reads
+    # secrets CI_APP_ID + CI_APP_PRIVATE_KEY (create the App with Contents:read
+    # on the repos and set the secrets at org level). Recommended.
+    "GitHub App (org-owned, per-run token)": app
+    # Personal access token stored as the PRIVATE_REPO_ACCESS_TOKEN secret.
+    "Personal access token (PRIVATE_REPO_ACCESS_TOKEN)": pat
 
 test_on_windows:
   type: bool

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -25,6 +25,20 @@ jobs:
           python-version: "[[ python_requires ]]"
 
 [% if private_repo_deps %]
+[% if private_repo_auth == "app" %]
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Configure git for private repos
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+[% else %]
       - name: Configure git for private repos
         env:
           PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
@@ -32,6 +46,7 @@ jobs:
           if [ -n "$PRIVATE_REPO_ACCESS_TOKEN" ]; then
             git config --global url."https://${PRIVATE_REPO_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
           fi
+[% endif %]
 
 [% endif %]
       - name: Install dependencies
@@ -65,6 +80,20 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
 [% if private_repo_deps %]
+[% if private_repo_auth == "app" %]
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.CI_APP_ID }}
+          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Configure git for private repos
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git config --global url."https://x-access-token:${GH_APP_TOKEN}@github.com/".insteadOf "https://github.com/"
+[% else %]
       - name: Configure git for private repos
         env:
           PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
@@ -72,6 +101,7 @@ jobs:
           if [ -n "$PRIVATE_REPO_ACCESS_TOKEN" ]; then
             git config --global url."https://${PRIVATE_REPO_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
           fi
+[% endif %]
 
 [% endif %]
       - name: Install dependencies


### PR DESCRIPTION
Adds a `private_repo_auth` copier question (asked only when `private_repo_deps`): **app** (default) wires `actions/create-github-app-token@v3` + an `x-access-token` git rewrite using org secrets `CI_APP_ID`/`CI_APP_PRIVATE_KEY`; **pat** keeps the existing `PRIVATE_REPO_ACCESS_TOKEN` rewrite. Verified via copier render (app/pat/off) + rendered-YAML parse.