### PR TITLE
docs: refresh CI docs (private_repo_auth, release flow, gate name)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
           test -f template/CITATION.cff
           test -f template/.pre-commit-config.yaml
           test -f "template/.github/workflows/ci.yml"
+          test -f "template/.github/workflows/versioning.yml"
           test -f "template/.github/workflows/release.yml"
           echo "All expected template files present."
 
@@ -69,8 +70,9 @@ jobs:
           grep -q "id-token: write" template/.github/workflows/release.yml
           # no prod branch
           ! grep -q "prod" template/.github/workflows/release.yml
-          # auto bump present in combined release workflow
-          grep -q "startsWith.*bump:" template/.github/workflows/release.yml
+          # auto bump lives in versioning.yml (split from the publish-only release.yml)
+          grep -q "startsWith.*bump:" template/.github/workflows/versioning.yml
+          grep -q "cz bump" template/.github/workflows/versioning.yml
           echo "All content checks passed."
 
       - name: Generate test project
@@ -96,14 +98,15 @@ jobs:
           test -f /tmp/test-output/VERSION               && echo "ok: VERSION"
           test -f /tmp/test-output/CITATION.cff          && echo "ok: CITATION.cff"
           test -f /tmp/test-output/.pre-commit-config.yaml && echo "ok: .pre-commit-config.yaml"
-          test -f /tmp/test-output/.github/workflows/ci.yml      && echo "ok: ci.yml"
-          test -f /tmp/test-output/.github/workflows/release.yml && echo "ok: release.yml"
-          test -f /tmp/test-output/.github/workflows/docs.yml    && echo "ok: docs.yml"
+          test -f /tmp/test-output/.github/workflows/ci.yml         && echo "ok: ci.yml"
+          test -f /tmp/test-output/.github/workflows/versioning.yml && echo "ok: versioning.yml"
+          test -f /tmp/test-output/.github/workflows/release.yml    && echo "ok: release.yml"
+          test -f /tmp/test-output/.github/workflows/docs.yml       && echo "ok: docs.yml"
           grep -q "test_project" /tmp/test-output/pyproject.toml && echo "ok: slug in pyproject"
           grep -q "1.0.0" /tmp/test-output/VERSION               && echo "ok: version in VERSION"
           grep -q "teal" /tmp/test-output/mkdocs.yml             && echo "ok: theme in mkdocs"
-          grep -q "trusted-publishing automatic" /tmp/test-output/.github/workflows/release.yml && echo "ok: oidc in release"
-          grep -q "uvx --from commitizen cz" /tmp/test-output/.github/workflows/release.yml     && echo "ok: cz entrypoint in release"
+          grep -q "trusted-publishing automatic" /tmp/test-output/.github/workflows/release.yml     && echo "ok: oidc in release"
+          grep -q "uvx --from commitizen cz" /tmp/test-output/.github/workflows/versioning.yml      && echo "ok: cz entrypoint in versioning"
           test -f /tmp/test-output/.githooks/fix_commit_msg.py && echo "ok: fix_commit_msg.py"
           test -f /tmp/test-output/.gitlint                  && echo "ok: .gitlint"
           grep -q "gitlint" /tmp/test-output/.pre-commit-config.yaml && echo "ok: gitlint in pre-commit"

--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ cd my-existing-project && copier update
 ## Release flow
 
 ```
-feature branch  →  PR  →  CI gate (lint + test + secrets) must pass
+feature branch  →  PR  →  CI gate (lint + test) must pass
                            merge blocked until green
                                ↓
                            merge to main (rebase)
                                ↓
-                           bump.yml fires: cz bump → tag vX.Y.Z
-                               ↓
-                           release.yml fires on tag:
+                           release.yml fires on push to main (one job):
+                           → cz bump → tag vX.Y.Z
                            → GitHub release (wheel + sdist attached)
                            → PyPI via OIDC trusted publishing (no stored token)
                            → Zenodo webhook (if enabled)

--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ feature branch  →  PR  →  CI gate (lint + test) must pass
                                ↓
                            merge to main (rebase)
                                ↓
-                           release.yml fires on push to main (one job):
-                           → cz bump → tag vX.Y.Z
+                           versioning.yml fires on push to main:
+                           → cz bump → tag vX.Y.Z → dispatch release.yml
+                               ↓
+                           release.yml (on tag / dispatch):
                            → GitHub release (wheel + sdist attached)
                            → PyPI via OIDC trusted publishing (no stored token)
                            → Zenodo webhook (if enabled)

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -16,15 +16,15 @@ Configure branch protection rules on GitHub to enforce the CI gate and allow aut
 | Require branches to be up to date | ✓ | No stale merges |
 | Require linear history | ✓ | Keeps git log readable |
 
-## Allow `release.yml` to push back to `main`
+## Allow `versioning.yml` to push back to `main`
 
-`release.yml` creates a version tag and pushes it after merging. GitHub's default branch protection blocks this. Fix:
+`versioning.yml` creates a version tag and pushes it after merging. GitHub's default branch protection blocks this. Fix:
 
 **Repository → Settings → Branches → main rule → Allow specified actors to bypass required pull requests**
 
 Add: `github-actions[bot]`
 
-Without this, the release workflow will fail with a 403 when trying to push the tag.
+Without this, the versioning workflow will fail with a 403 when trying to push the tag.
 
 ## Required status check name
 

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -16,19 +16,19 @@ Configure branch protection rules on GitHub to enforce the CI gate and allow aut
 | Require branches to be up to date | ✓ | No stale merges |
 | Require linear history | ✓ | Keeps git log readable |
 
-## Allow `bump.yml` to push back to `main`
+## Allow `release.yml` to push back to `main`
 
-`bump.yml` creates a version tag and pushes it after merging. GitHub's default branch protection blocks this. Fix:
+`release.yml` creates a version tag and pushes it after merging. GitHub's default branch protection blocks this. Fix:
 
 **Repository → Settings → Branches → main rule → Allow specified actors to bypass required pull requests**
 
 Add: `github-actions[bot]`
 
-Without this, the bump workflow will fail with a 403 when trying to push the tag.
+Without this, the release workflow will fail with a 403 when trying to push the tag.
 
 ## Required status check name
 
-The aggregate job in `ci.yml` is named `CI`. This is what to enter in the required status checks field. It passes only when `lint` and `secrets-scan` both succeed.
+The aggregate job in `ci.yml` is named `CI`. This is what to enter in the required status checks field. It passes only when `lint` and `test` both succeed (gitleaks runs inside pre-commit, not a separate job).
 
 ## Rulesets (modern alternative)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,8 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 | `python_requires` | `3.10`-`3.14`, default `3.13` | Minimum supported Python version; controls `requires-python` and test matrix |
 | `license_type` | `noncommercial` / `bsd3` | `noncommercial` for MSW-core packages; `bsd3` for standalone hardware drivers |
 | `private_repo_deps` | `false` / `true`, default `false` | Set `true` only if the repo has private GitHub dependencies; injects a git auth step in CI. All standard repos use `false` (PyPI deps only). |
+| `private_repo_auth` | `app` / `pat`, default `app` (asked only when `private_repo_deps=true`) | How CI authenticates to clone the private deps. **app** = org-owned GitHub App, per-run token via `actions/create-github-app-token@v3` (org secrets `CI_APP_ID` + `CI_APP_PRIVATE_KEY`; the App needs Contents:read on the private repos). **pat** = the `PRIVATE_REPO_ACCESS_TOKEN` secret. See [Private repo auth](private-repo-auth.md). |
+| `test_on_windows` | `false` / `true`, default `false` | Adds `windows-latest` to the CI test matrix (for path-sensitive or Windows-targeted packages). |
 
 ## Apply template updates to an existing project
 
@@ -97,7 +99,7 @@ uv run pytest                      # run tests
 uv run pre-commit run --all-files  # run all lint checks manually
 ```
 
-Version bumping and releasing are handled automatically by `bump.yml` and `release.yml` on every merge to `main`. Manual override:
+Version bumping and releasing are handled automatically by `release.yml` on every merge to `main` (it runs `cz bump`, tags, builds, and publishes in one job). Manual override:
 
 ```sh
 cz bump && git push --follow-tags
@@ -118,8 +120,8 @@ my-project/
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml               # lint on push; tests on PR to main
-│       ├── bump.yml             # auto cz bump on merge to main
-│       ├── release.yml          # on v* tag: GitHub release + PyPI (OIDC)
+│       ├── release.yml          # on merge to main: cz bump → build → GitHub release + PyPI (OIDC)
+│       ├── pr-review.yml        # automated PR review
 │       └── docs.yml             # deploy MkDocs to GitHub Pages on push to main
 ├── pyproject.toml
 ├── CITATION.cff                 # citation metadata for Zenodo + GitHub

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ uv run pytest                      # run tests
 uv run pre-commit run --all-files  # run all lint checks manually
 ```
 
-Version bumping and releasing are handled automatically by `release.yml` on every merge to `main` (it runs `cz bump`, tags, builds, and publishes in one job). Manual override:
+Version bumping and releasing are handled automatically on every merge to `main`: `versioning.yml` runs `cz bump`, pushes the tag, and dispatches `release.yml`, which builds and publishes. Manual override:
 
 ```sh
 cz bump && git push --follow-tags
@@ -120,7 +120,8 @@ my-project/
 ├── .github/
 │   └── workflows/
 │       ├── ci.yml               # lint on push; tests on PR to main
-│       ├── release.yml          # on merge to main: cz bump → build → GitHub release + PyPI (OIDC)
+│       ├── versioning.yml       # on merge to main: cz bump + tag, dispatches release.yml
+│       ├── release.yml          # on tag/dispatch: build → GitHub release + PyPI (OIDC)
 │       ├── pr-review.yml        # automated PR review
 │       └── docs.yml             # deploy MkDocs to GitHub Pages on push to main
 ├── pyproject.toml

--- a/docs/private-repo-auth.md
+++ b/docs/private-repo-auth.md
@@ -1,0 +1,51 @@
+# Private repo dependencies (CI auth)
+
+If your package depends on **private** GitHub repos (e.g. `git+`/workspace deps that
+aren't on PyPI), CI needs credentials to clone them. Set `private_repo_deps=true` at
+generation time and pick how CI authenticates via `private_repo_auth`.
+
+Only **private** dependency repos need this — public deps clone anonymously.
+
+## `app` — org-owned GitHub App (default, recommended)
+
+CI mints a short-lived, per-run installation token via
+`actions/create-github-app-token@v3`, then rewrites git to use it:
+
+```yaml
+- uses: actions/create-github-app-token@v3
+  id: app-token
+  with:
+    app-id: ${{ secrets.CI_APP_ID }}
+    private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+    owner: ${{ github.repository_owner }}
+- run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
+```
+
+Setup (once per org):
+
+1. Create an **org-owned** GitHub App: `https://github.com/organizations/<ORG>/settings/apps/new` — **Contents: Read-only**, webhook off.
+2. Generate a private key (`.pem`) and note the **App ID**.
+3. **Install** the App on the **private** repos that CI clones (Contents:read). The
+   repo running the workflow does *not* need to be installed (it mints via `owner:`
+   and checks itself out with the default `GITHUB_TOKEN`).
+4. Add two **org** secrets: `CI_APP_ID` (the App ID) and `CI_APP_PRIVATE_KEY` (the `.pem`).
+
+Why this over a PAT: not tied to any user, tokens are short-lived and auto-expire
+(nothing to rotate), and access is scoped to the installed repos.
+
+## `pat` — personal access token
+
+CI uses a `PRIVATE_REPO_ACCESS_TOKEN` secret:
+
+```yaml
+- env:
+    PRIVATE_REPO_ACCESS_TOKEN: ${{ secrets.PRIVATE_REPO_ACCESS_TOKEN }}
+  run: |
+    if [ -n "$PRIVATE_REPO_ACCESS_TOKEN" ]; then
+      git config --global url."https://${PRIVATE_REPO_ACCESS_TOKEN}@github.com/".insteadOf "https://github.com/"
+    fi
+```
+
+Setup: create a fine-grained PAT with **Contents: Read-only** on the private dep repos
+and store it as the `PRIVATE_REPO_ACCESS_TOKEN` secret (repo or org level). Simpler, but
+tied to a user account and expires (≤1 year) — prefer `app` for shared/long-lived infra.

--- a/docs/pypi-publishing.md
+++ b/docs/pypi-publishing.md
@@ -18,7 +18,7 @@ That's it. The workflow handles authentication automatically — no token, no se
 
 ## Trigger a release
 
-Releases are triggered automatically by `release.yml` on every merge to `main`. To trigger manually:
+Releases are triggered automatically on every merge to `main` (`versioning.yml` bumps + tags, then dispatches `release.yml`). To trigger manually:
 
 ```sh
 cz bump

--- a/docs/pypi-publishing.md
+++ b/docs/pypi-publishing.md
@@ -18,7 +18,7 @@ That's it. The workflow handles authentication automatically — no token, no se
 
 ## Trigger a release
 
-Releases are triggered automatically by `bump.yml` on every merge to `main`. To trigger manually:
+Releases are triggered automatically by `release.yml` on every merge to `main`. To trigger manually:
 
 ```sh
 cz bump

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -28,9 +28,12 @@ gh pr create --base main --title "feat: my feature"
 # 5. Merge PR (rebase or squash)
 gh pr merge --rebase --delete-branch
 
-# 6. release.yml fires automatically on push to main (one job):
+# 6. versioning.yml fires automatically on push to main:
 #    → reads commits since last tag, runs cz bump --yes (patch/minor/major)
 #    → creates + pushes version tag (e.g. v1.3.0)
+#    → dispatches release.yml
+
+# 7. release.yml (on the tag / dispatch):
 #    → builds wheel + sdist
 #    → creates GitHub release with dist files attached
 #    → publishes to PyPI via OIDC trusted publishing (no stored token)
@@ -47,7 +50,7 @@ Commitizen reads all commits since the previous tag:
 | at least one `feat:` | **minor** `0.x.0` |
 | `BREAKING CHANGE:` footer or `feat!:`/`fix!:` | **major** `x.0.0` |
 
-If there are no bumpable commits since the last tag, `release.yml` exits silently — no error, no tag.
+If there are no bumpable commits since the last tag, `versioning.yml` exits silently — no error, no tag.
 
 ## Manual bump (override)
 

--- a/docs/release-workflow.md
+++ b/docs/release-workflow.md
@@ -28,12 +28,9 @@ gh pr create --base main --title "feat: my feature"
 # 5. Merge PR (rebase or squash)
 gh pr merge --rebase --delete-branch
 
-# 6. bump.yml fires automatically on push to main:
-#    → reads commits since last tag
-#    → runs cz bump --yes to determine patch/minor/major
-#    → creates version tag (e.g. v1.3.0) and pushes it
-
-# 7. release.yml fires on the new tag:
+# 6. release.yml fires automatically on push to main (one job):
+#    → reads commits since last tag, runs cz bump --yes (patch/minor/major)
+#    → creates + pushes version tag (e.g. v1.3.0)
 #    → builds wheel + sdist
 #    → creates GitHub release with dist files attached
 #    → publishes to PyPI via OIDC trusted publishing (no stored token)
@@ -50,7 +47,7 @@ Commitizen reads all commits since the previous tag:
 | at least one `feat:` | **minor** `0.x.0` |
 | `BREAKING CHANGE:` footer or `feat!:`/`fix!:` | **major** `x.0.0` |
 
-If there are no bumpable commits since the last tag, `bump.yml` exits silently — no error, no tag.
+If there are no bumpable commits since the last tag, `release.yml` exits silently — no error, no tag.
 
 ## Manual bump (override)
 
@@ -76,10 +73,6 @@ git push --follow-tags
 Common types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`.
 
 ## Common issues
-
-**`bump.yml` pushed a tag but `release.yml` didn't trigger**
-
-GitHub prevents downstream `push` triggers when `GITHUB_TOKEN` is the actor. If this happens, store a PAT as `BUMP_TOKEN` and set `token: ${{ secrets.BUMP_TOKEN }}` in the checkout step of `bump.yml`.
 
 **`cz bump` fails with exit code 128**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,3 +34,4 @@ nav:
   - Local CI with act: local-ci.md
   - Pre-commit hooks: pre-commit.md
   - Branch protection: branch-protection.md
+  - Private repo auth: private-repo-auth.md

--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -1,9 +1,17 @@
 name: Release
 
+# Publish only. Triggered by a tag (hand-pushed tags publish directly) or by a
+# workflow_dispatch from versioning.yml (a GITHUB_TOKEN-pushed tag cannot trigger
+# push:tags). Stays named release.yml so the PyPI trusted-publisher (OIDC) binding
+# is unchanged.
 on:
   push:
-    branches: [main]
+    tags: ["v*"]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish (e.g. v0.1.2)"
+        required: true
 
 permissions:
   contents: write
@@ -11,50 +19,27 @@ permissions:
 
 jobs:
   release:
-    name: Bump, build, publish
+    name: Build and publish
     runs-on: ubuntu-latest
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     steps:
       - uses: actions/checkout@v6
         with:
+          ref: "${{ github.event.inputs.tag || github.ref }}"
           fetch-depth: 0
-
-      - name: Configure git identity
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
 
       - uses: astral-sh/setup-uv@v7
         with:
           python-version: "[[ python_requires ]]"
 
-      - name: Bump version
-        id: bump
-        run: |
-          uvx --from commitizen cz bump --yes || EXIT=$?
-          if [ "${EXIT:-0}" -eq 21 ] || [ "${EXIT:-0}" -eq 6 ]; then
-            echo "No bumpable commits since last tag — skipping."
-            echo "skipped=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          [ "${EXIT:-0}" -eq 0 ] || exit $EXIT
-          VERSION=$(cat VERSION)
-          git push origin HEAD:main
-          git push origin "v${VERSION}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-
       - name: Build
-        if: steps.bump.outputs.skipped != 'true'
         run: uv build
 
       - name: Create GitHub release
-        if: steps.bump.outputs.skipped != 'true'
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: "v${{ steps.bump.outputs.version }}"
+          tag_name: "${{ github.event.inputs.tag || github.ref_name }}"
           files: dist/*
           generate_release_notes: false
 
       - name: Publish to PyPI
-        if: steps.bump.outputs.skipped != 'true'
         run: uv publish --trusted-publishing automatic

--- a/template/.github/workflows/versioning.yml
+++ b/template/.github/workflows/versioning.yml
@@ -1,0 +1,48 @@
+name: Versioning
+
+# Bump + tag only. Publishing is decoupled into release.yml (so the PyPI OIDC
+# trusted-publisher stays bound to release.yml, and a hand-pushed tag publishes too).
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  actions: write  # to dispatch release.yml
+
+jobs:
+  version:
+    name: Bump and tag
+    runs-on: ubuntu-latest
+    # Skip the bump the bot itself just pushed (avoids a loop).
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "[[ python_requires ]]"
+
+      - name: Bump, tag, trigger release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          uvx --from commitizen cz bump --yes || EXIT=$?
+          if [ "${EXIT:-0}" -eq 21 ] || [ "${EXIT:-0}" -eq 6 ]; then
+            echo "No bumpable commits since last tag — nothing to release."
+            exit 0
+          fi
+          [ "${EXIT:-0}" -eq 0 ] || exit $EXIT
+          VERSION="v$(cat VERSION)"
+          git push origin HEAD:main
+          git push origin "$VERSION"
+          # A GITHUB_TOKEN-pushed tag does NOT trigger release.yml's push:tags,
+          # so dispatch the publish explicitly for the automatic path.
+          gh workflow run release.yml -f tag="$VERSION"

--- a/template/README.md
+++ b/template/README.md
@@ -5,13 +5,13 @@
 ## Installation
 
 ```sh
-pip install [[ project_slug ]]
+uv add [[ project_slug ]]
 ```
 
-Or with uv:
+Or with pip:
 
 ```sh
-uv add [[ project_slug ]]
+pip install [[ project_slug ]]
 ```
 
 ## Development setup


### PR DESCRIPTION
Documentation-only. Documents the new `private_repo_auth` copier option (App vs PAT) + the secrets it needs (`CI_APP_ID`/`CI_APP_PRIVATE_KEY` or `PRIVATE_REPO_ACCESS_TOKEN`); fixes stale `bump.yml` references (the generated payload ships a single combined `release.yml`); corrects the CI-gate description (no `secrets-scan` job — gate is `lint`+`test`); adds `test_on_windows` to the questions table; leads the generated README install with `uv add`. Verified with a copier render.

Flagged (not changed here): the generated **payload** uses a single combined `release.yml` (bump+build+publish) — it is *not* split into `versioning.yml`+`release.yml` like the labwatch repos. Decide whether to split the payload before docs describe a split.