### PR TITLE
docs: align release-flow README with the merge-commit standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ cd my-existing-project && copier update
 feature branch  →  PR  →  CI gate (lint + test) must pass
                            merge blocked until green
                                ↓
-                           merge to main (rebase)
+                           merge to main (merge commit)
                                ↓
                            versioning.yml fires on push to main:
                            → cz bump → tag vX.Y.Z → dispatch release.yml


### PR DESCRIPTION
The README release-flow diagram said 'merge to main (rebase)'; the standard is a merge commit. Everything else in the README matches the actual workflow function (CI aggregate gate, versioning.yml bump+tag+dispatch, release.yml PyPI-via-OIDC + GitHub release, Zenodo external webhook).