### PR TITLE
feat(ci): app token via client-id; noncommercial license = BSD-3-NC

### DIFF
--- a/copier.yaml
+++ b/copier.yaml
@@ -78,9 +78,9 @@ year:
 
 license_type:
   type: str
-  help: "Licence for the generated project. noncommercial = custom MSW licence (research/academic only, no commercial use without agreement). bsd3 = BSD-3-Clause (hardware wrappers and utilities — allows commercial use)."
+  help: "Licence for the generated project. noncommercial = BSD-3-Clause-NonCommercial (BSD-3 terms plus a non-commercial clause; research/academic/education only, commercial use needs a separate agreement). bsd3 = BSD-3-Clause (hardware wrappers and utilities — allows commercial use)."
   choices:
-    "Custom noncommercial (MSW default)": noncommercial
+    "BSD-3 + non-commercial clause (default)": noncommercial
     "BSD-3-Clause (hardware wrappers / utilities)": bsd3
   default: noncommercial
 
@@ -95,12 +95,25 @@ private_repo_auth:
   when: "[[ private_repo_deps ]]"
   default: app
   choices:
-    # Org-owned GitHub App: per-run installation token, no user PAT. CI reads
-    # secrets CI_APP_ID + CI_APP_PRIVATE_KEY (create the App with Contents:read
-    # on the repos and set the secrets at org level). Recommended.
+    # Org-owned GitHub App: per-run installation token, no user PAT. CI mints via
+    # `client-id` (the App's Client ID, Iv23li…) + its private key, read from the
+    # secrets named below (create the App with Contents:read on the repos and set
+    # the secrets at org level). Recommended.
     "GitHub App (org-owned, per-run token)": app
     # Personal access token stored as the PRIVATE_REPO_ACCESS_TOKEN secret.
     "Personal access token (PRIVATE_REPO_ACCESS_TOKEN)": pat
+
+ci_app_client_id_secret:
+  type: str
+  help: "Actions secret holding the GitHub App Client ID (Iv23li…) CI mints tokens with. Rename per org (e.g. MURINESHIFTWORK_CI_CLIENT_ID) or keep the generic default."
+  when: "[[ private_repo_deps and private_repo_auth == 'app' ]]"
+  default: CI_APP_CLIENT_ID
+
+ci_app_private_key_secret:
+  type: str
+  help: "Actions secret holding the GitHub App private key (.pem) paired with that Client ID."
+  when: "[[ private_repo_deps and private_repo_auth == 'app' ]]"
+  default: CI_APP_PRIVATE_KEY
 
 test_on_windows:
   type: bool

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,7 +51,7 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 | `python_requires` | `3.10`-`3.14`, default `3.13` | Minimum supported Python version; controls `requires-python` and test matrix |
 | `license_type` | `noncommercial` / `bsd3` | `noncommercial` for MSW-core packages; `bsd3` for standalone hardware drivers |
 | `private_repo_deps` | `false` / `true`, default `false` | Set `true` only if the repo has private GitHub dependencies; injects a git auth step in CI. All standard repos use `false` (PyPI deps only). |
-| `private_repo_auth` | `app` / `pat`, default `app` (asked only when `private_repo_deps=true`) | How CI authenticates to clone the private deps. **app** = org-owned GitHub App, per-run token via `actions/create-github-app-token@v3` (org secrets `CI_APP_ID` + `CI_APP_PRIVATE_KEY`; the App needs Contents:read on the private repos). **pat** = the `PRIVATE_REPO_ACCESS_TOKEN` secret. See [Private repo auth](private-repo-auth.md). |
+| `private_repo_auth` | `app` / `pat`, default `app` (asked only when `private_repo_deps=true`) | How CI authenticates to clone the private deps. **app** = org-owned GitHub App, per-run token via `actions/create-github-app-token@v3` using `client-id` (org secrets `CI_APP_CLIENT_ID` + `CI_APP_PRIVATE_KEY`, names configurable; the App needs Contents:read on the private repos). **pat** = the `PRIVATE_REPO_ACCESS_TOKEN` secret. See [Private repo auth](private-repo-auth.md). |
 | `test_on_windows` | `false` / `true`, default `false` | Adds `windows-latest` to the CI test matrix (for path-sensitive or Windows-targeted packages). |
 
 ## Apply template updates to an existing project

--- a/docs/private-repo-auth.md
+++ b/docs/private-repo-auth.md
@@ -15,20 +15,27 @@ CI mints a short-lived, per-run installation token via
 - uses: actions/create-github-app-token@v3
   id: app-token
   with:
-    app-id: ${{ secrets.CI_APP_ID }}
+    client-id: ${{ secrets.CI_APP_CLIENT_ID }}
     private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
     owner: ${{ github.repository_owner }}
 - run: git config --global url."https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/".insteadOf "https://github.com/"
 ```
 
+The token step uses `client-id` (the App's **Client ID**), not the deprecated `app-id`
+input. The secret names are copier variables — `ci_app_client_id_secret` (default
+`CI_APP_CLIENT_ID`) and `ci_app_private_key_secret` (default `CI_APP_PRIVATE_KEY`) — so
+an org with several Apps can scope them (e.g. `MYORG_CI_CLIENT_ID`). The Client ID and
+the private key **must belong to the same App**, or the token mint fails with
+`A JSON web token could not be decoded`.
+
 Setup (once per org):
 
 1. Create an **org-owned** GitHub App: `https://github.com/organizations/<ORG>/settings/apps/new` — **Contents: Read-only**, webhook off.
-2. Generate a private key (`.pem`) and note the **App ID**.
+2. Generate a private key (`.pem`) and note the **Client ID** (`Iv23li…`, on the App's General page).
 3. **Install** the App on the **private** repos that CI clones (Contents:read). The
    repo running the workflow does *not* need to be installed (it mints via `owner:`
    and checks itself out with the default `GITHUB_TOKEN`).
-4. Add two **org** secrets: `CI_APP_ID` (the App ID) and `CI_APP_PRIVATE_KEY` (the `.pem`).
+4. Add two **org** secrets: `CI_APP_CLIENT_ID` (the App's Client ID) and `CI_APP_PRIVATE_KEY` (the `.pem`).
 
 Why this over a PAT: not tied to any user, tokens are short-lived and auto-expire
 (nothing to rotate), and access is scoped to the installed repos.

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -29,8 +29,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.[[ ci_app_client_id_secret ]] }}
+          private-key: ${{ secrets.[[ ci_app_private_key_secret ]] }}
           owner: ${{ github.repository_owner }}
 
       - name: Configure git for private repos
@@ -84,8 +84,8 @@ jobs:
       - uses: actions/create-github-app-token@v3
         id: app-token
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.[[ ci_app_client_id_secret ]] }}
+          private-key: ${{ secrets.[[ ci_app_private_key_secret ]] }}
           owner: ${{ github.repository_owner }}
 
       - name: Configure git for private repos

--- a/template/LICENSE
+++ b/template/LICENSE
@@ -30,35 +30,39 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 [% else %]
-Copyright (c) [[ year ]]-present [[ author_name ]]. All rights reserved.
+BSD-3-Clause-NonCommercial
 
-Permission is granted, free of charge, to use, copy, modify, and distribute
-this software and associated documentation files (the "Software") for
-non-commercial research or academic purposes only, subject to the following
-conditions:
+Copyright (c) [[ year ]]-present, [[ author_name ]].
+All rights reserved.
 
-1. This copyright notice and permission notice must be included in all copies
-   or substantial portions of the Software.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted for NON-COMMERCIAL research, academic, and
+educational purposes only, provided that the following conditions are met:
 
-2. Any publication, presentation, or product that uses or builds upon the
-   Software must give clear attribution to the original work and its authors.
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
 
-3. Commercial use is prohibited without a separate written commercial licence
-   agreement with the copyright holder. Commercial use means incorporation of
-   the Software into anything for which fees or other compensation are charged
-   or received, including commercial products and commercial services.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-4. No patent licence, express or implied, is granted under these terms. Any
-   use that would require a patent licence from the copyright holder requires
-   a separate written agreement.
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
 
-5. Redistribution, in source or binary form, is permitted only for
-   non-commercial purposes and must retain this notice unmodified.
+4. Any use of this software or its derivatives for COMMERCIAL purposes -
+   including sale, paid licensing, or providing paid services built on it -
+   requires a separate commercial licence. Contact [[ author_email ]].
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM,
-DAMAGES, OR OTHER LIABILITY ARISING FROM, OUT OF, OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR DEALINGS IN THE SOFTWARE.
-
-For commercial or patent licensing enquiries contact: [[ author_email ]]
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
 [% endif -%]


### PR DESCRIPTION
Generated repos previously minted the private-repo app token with the **deprecated `app-id`** input. Switch to `client-id` (the App's Client ID), reading the Client ID + private key from **copier-configurable secret names** — `ci_app_client_id_secret` (default `CI_APP_CLIENT_ID`) and `ci_app_private_key_secret` (default `CI_APP_PRIVATE_KEY`) — so an org running several Apps can scope them (e.g. `MURINESHIFTWORK_CI_*`). Generic default keeps the template org-agnostic.

Also: the **noncommercial** license option now emits **BSD-3-Clause-NonCommercial** (BSD-3 terms + a non-commercial clause) instead of the older MIT-style grant, matching the downstream fleet.

Docs (`private-repo-auth.md`, `index.md`) + copier help updated. Verified by local `copier` render: generic default, custom-name override, and the BSD-3-NC body all render correctly.